### PR TITLE
Parser class: Shorten prepareAdd() method

### DIFF
--- a/data/tong.txt
+++ b/data/tong.txt
@@ -1,2 +1,3 @@
 T | 0 | skateboarding@Lakeside
 T | 0 | slayy
+D | 0 | ip | 2023-08-30T23:59

--- a/src/main/java/slay/Message.java
+++ b/src/main/java/slay/Message.java
@@ -4,11 +4,15 @@ package slay;
  * Container for user visible messages.
  */
 public class Message {
-
     public static final String MESSAGE_WELCOME = "WORK. PLAY. SLAY.\n"
         + "Let's slay your tasks and slay the day!";
     public static final String MESSAGE_PROMPT = "Explore how I can help you SLAY by simply typing 'help':D";
     public static final String MESSAGE_GOODBYE = "YOU SLAY THE DAY! Have a good rest. See you!";
+
+    public static final String MESSAGE_INCORRECT_ADD_FORMAT = "Sorry, I can't understand your task:(\n"
+            + "You may retype task following this format:\n";
+    public static final String MESSAGE_INCORRECT_ADD_TASK_KEYWORD = "Sorry, I don't know this type of tasks:(\n"
+            + "You may choose from what I have:D\n";
 
     public static final String MESSAGE_INVALID_TASK_INDEX = "The task index seems to be invalid."
             + "Double check and try it again!";

--- a/src/main/java/slay/Parser.java
+++ b/src/main/java/slay/Parser.java
@@ -1,6 +1,7 @@
 package slay;
 
 import slay.command.*;
+import slay.exception.IncorrectDescriptionFormatException;
 import slay.task.Deadline;
 import slay.task.Event;
 import slay.task.ToDo;
@@ -77,70 +78,104 @@ public class Parser {
      * @return the prepared command
      */
     private Command prepareAdd(String args) {
-        final Matcher matcher = TASK_ARGS_FORMAT.matcher(args.trim());
-        if (!matcher.matches()) {
-            return new IncorrectCommand("Sorry, I don't know this type of tasks:(\n"
-                    + "You may choose from what I have:D\n"
-                    + AddCommand.MESSAGE_USAGE);
-        }
-
-        String type = matcher.group("type");
-        String description = matcher.group("description");
-
-        switch (type) {
-        case ToDo.TYPE:
-            ToDo todo = new ToDo(description);
-            return new AddCommand(todo);
-
-        case Deadline.TYPE:
-            final Matcher matcherDeadline = DEADLINE_DES_FORMAT.matcher(description.trim());
-            if (!matcherDeadline.matches()) {
-                return new IncorrectCommand("Invalid Format:(\n"
-                        + "Could you talk in the ways that I can understand:D\n"
+        try {
+            final Matcher matcher = TASK_ARGS_FORMAT.matcher(args.trim());
+            if (!matcher.matches()) {
+                return new IncorrectCommand(Message.MESSAGE_INCORRECT_ADD_FORMAT
                         + AddCommand.MESSAGE_USAGE);
             }
 
-            String deadlineDes = matcherDeadline.group("description");
-            String ddl = matcherDeadline.group("deadline");
-            String[] ddlSplit = ddl.split(" ");
-            String date = ddlSplit[0];
-            String time = ddlSplit[1];
+            String type = matcher.group("type");
+            String description = matcher.group("description");
 
-            Deadline deadline = new Deadline(deadlineDes, date, time);
-            return new AddCommand(deadline);
+            switch (type) {
+                case ToDo.TYPE:
+                    ToDo todo = new ToDo(description);
+                    return new AddCommand(todo);
 
-        case Event.TYPE:
-            final Matcher matcherEvent = EVENT_DES_FORMAT.matcher(description.trim());
-            if (!matcherEvent.matches()) {
-                return new IncorrectCommand("Invalid Format:(\n"
-                        + "Could you talk in the ways that I can understand:D\n"
-                        + AddCommand.MESSAGE_USAGE);
+                case Deadline.TYPE:
+                    String[] parsedDeadlineArgs = parseDeadlineArgs(description);
+                    Deadline deadline = new Deadline(
+                            parsedDeadlineArgs[0],
+                            parsedDeadlineArgs[1],
+                            parsedDeadlineArgs[2]);
+                    return new AddCommand(deadline);
+
+                case Event.TYPE:
+                    String[] parsedEventArgs = parseEventArgs(description);
+                    Event event = new Event(
+                            parsedEventArgs[0],
+                            parsedEventArgs[1],
+                            parsedEventArgs[2],
+                            parsedEventArgs[3],
+                            parsedEventArgs[4]);
+                    return new AddCommand(event);
+
+                default:
+                    return new IncorrectCommand(Message.MESSAGE_INCORRECT_ADD_TASK_KEYWORD
+                            + AddCommand.MESSAGE_USAGE);
             }
-
-            String eventDes = matcherEvent.group("description");
-            String start = matcherEvent.group("start");
-            String end = matcherEvent.group("end");
-            String[] startSplit = start.split(" ");
-            String[] endSplit = end.split(" ");
-            String fromDate = startSplit[0];
-            String fromTime = startSplit[1];
-            String toDate = endSplit[0];
-            String toTime = endSplit[1];
-
-            Event event = new Event(eventDes, fromDate, fromTime, toDate, toTime);
-            return new AddCommand(event);
-
-        default:
-            return new IncorrectCommand("Sorry, I don't know this type of tasks:(\n"
-                    + "You may choose from what I have:D\n"
+        } catch (IncorrectDescriptionFormatException e) {
+            return new IncorrectCommand(Message.MESSAGE_INCORRECT_ADD_FORMAT
                     + AddCommand.MESSAGE_USAGE);
         }
     }
 
     /**
+     * Parses arguments in the context of the add deadline command.
+     *
+     * @param description full command args string containing deadline description,
+     *                    deadline date and time.
+     * @return a String array of the parsed command
+     */
+    private String[] parseDeadlineArgs(String description) throws IncorrectDescriptionFormatException {
+        final Matcher matcherDeadline = DEADLINE_DES_FORMAT.matcher(description.trim());
+        if (!matcherDeadline.matches()) {
+            throw new IncorrectDescriptionFormatException();
+        }
+
+        String deadlineDes = matcherDeadline.group("description");
+        String ddl = matcherDeadline.group("deadline");
+        String[] ddlSplit = ddl.split(" ");
+        String date = ddlSplit[0];
+        String time = ddlSplit[1];
+
+        String[] parsedArgs = {deadlineDes, date, time};
+        return parsedArgs;
+    }
+
+    /**
+     * Parses arguments in the context of the add event command.
+     *
+     * @param description full command args string containing event description,
+     *                    event start date and time, event end date and time.
+     * @return a String array of the parsed command
+     */
+    private String[] parseEventArgs(String description) throws IncorrectDescriptionFormatException {
+        final Matcher matcherEvent = EVENT_DES_FORMAT.matcher(description.trim());
+        if (!matcherEvent.matches()) {
+            throw new IncorrectDescriptionFormatException();
+        }
+
+        String eventDes = matcherEvent.group("description");
+        String start = matcherEvent.group("start");
+        String end = matcherEvent.group("end");
+        String[] startSplit = start.split(" ");
+        String[] endSplit = end.split(" ");
+        String fromDate = startSplit[0];
+        String fromTime = startSplit[1];
+        String toDate = endSplit[0];
+        String toTime = endSplit[1];
+
+        String[] parsedArgs = {eventDes, fromDate, fromTime, toDate, toTime};
+
+        return parsedArgs;
+    }
+
+    /**
      * Parses arguments in the context of the delete task command.
      *
-     * @param args full command args string
+     * @param args command args string which is supposed to be an integer
      * @return the prepared command
      */
     private Command prepareDelete(String args) {
@@ -154,11 +189,23 @@ public class Parser {
         }
     }
 
+    /**
+     * Parses arguments in the context of the mark task command.
+     *
+     * @param args command args string which is supposed to be an integer
+     * @return the prepared command
+     */
     private Command prepareMark(String args) {
         int targetVisibleIndex = Integer.parseInt(args);
         return new MarkCommand(targetVisibleIndex);
     }
 
+    /**
+     * Parses arguments in the context of the unmark task command.
+     *
+     * @param args command args string which is supposed to be an integer
+     * @return the prepared command
+     */
     private Command prepareUnmark(String args) {
         int targetVisibleIndex = Integer.parseInt(args);
         return new UnmarkCommand(targetVisibleIndex);

--- a/src/main/java/slay/Slay.java
+++ b/src/main/java/slay/Slay.java
@@ -11,22 +11,22 @@ import slay.command.ExitCommand;
  */
 public class Slay {
     private Storage storage;
-    private TaskList tasks;
+    private TaskList taskList;
     private Ui ui;
     private Parser parser;
 
     public Slay() {
         ui = new Ui();
         storage = new Storage();
-        tasks = storage.load();
+        taskList = storage.load();
         parser = new Parser();
     }
 
     public String getResponse(String userInput) {
         Command c = parser.parse(userInput);
-        c.setData(this.tasks);
+        c.setData(this.taskList);
         CommandResult result = c.execute();
-        storage.save(this.tasks);
+        storage.save(this.taskList);
         return ui.showResultToUser(result);
     }
 }

--- a/src/main/java/slay/exception/IncorrectDescriptionFormatException.java
+++ b/src/main/java/slay/exception/IncorrectDescriptionFormatException.java
@@ -1,0 +1,10 @@
+package slay.exception;
+
+/**
+ * Signals a wrong format of description for an AddCommand.
+ */
+public class IncorrectDescriptionFormatException extends Exception {
+    public IncorrectDescriptionFormatException() {
+        super("Error: Cannot understand the description format.");
+    }
+}


### PR DESCRIPTION
The prepareAdd() method is very long due to the complexity in parsing the command arguments of deadline and event tasks. This makes the code less readable.

Extract the implementation of parsing into two seperate methods and shorten prepareAdd() method.